### PR TITLE
Link to "https://bterlson.github.com/ecmarkup/elements.css"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <meta charset="utf8">
 <title>SIMD.js specification v0.5.5</title>
-<link rel="stylesheet" href="./elements.css">
+<link rel="stylesheet" href="https://bterlson.github.com/ecmarkup/elements.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
 <emu-biblio href="./biblio.json"></emu-biblio>
 <h1>SIMD.js specification</h1>


### PR DESCRIPTION
Instead of to missing ./elements.css. bterlson-approved for styled output ;-).

/be